### PR TITLE
キューワーカーを追加

### DIFF
--- a/app/app/Http/Controllers/Queue.php
+++ b/app/app/Http/Controllers/Queue.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Jobs\Hello;
+
+class Queue extends Controller
+{
+    public function __invoke()
+    {
+        $this->dispatch(new Hello());
+        return response('App\Job\Hello has been queued.');
+    }
+}

--- a/app/app/Jobs/Hello.php
+++ b/app/app/Jobs/Hello.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class Hello implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        logger()->info('Hello !!', [
+            'method' => __METHOD__
+        ]);
+    }
+}

--- a/app/app/Providers/RouteServiceProvider.php
+++ b/app/app/Providers/RouteServiceProvider.php
@@ -26,7 +26,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string|null
      */
-    // protected $namespace = 'App\\Http\\Controllers';
+     protected $namespace = 'App\\Http\\Controllers';
 
     /**
      * Define your route model bindings, pattern filters, etc.

--- a/app/config/logging.php
+++ b/app/config/logging.php
@@ -37,7 +37,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => ['daily', 'stderr'],
             'ignore_exceptions' => false,
         ],
 

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -16,3 +16,5 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('queues', 'Queue');

--- a/aws/cloud-formation/queue-worker/code-pipeline.yml
+++ b/aws/cloud-formation/queue-worker/code-pipeline.yml
@@ -1,0 +1,214 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  StackFamily:
+    Type: String
+    Default: ecs-blue-green-demo
+  GitHubOwner:
+    Type: String
+    Default: imunew
+  GitHubRepository:
+    Type: String
+    Default: ecs-blue-green-demo
+  GitHubBranch:
+    Type: String
+    Default: main
+  GithubTokenSecret:
+    Type: String
+    Default: main
+
+Resources:
+  PilelineArtifactStore:
+    Type: AWS::S3::Bucket
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  BuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "${StackFamily}-queue-worker-codebuild"
+      RetentionInDays: 14
+
+  BuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "codebuild.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        -
+          PolicyName: CodeBuild
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:*
+                  - iam:PassRole
+                  - secretsmanager:GetSecretValue
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:List*
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+                Resource:
+                  - !Join ['', ['arn:aws:s3:::', !Ref PilelineArtifactStore]]
+                  - !Join ['', ['arn:aws:s3:::', !Ref PilelineArtifactStore, '/*']]
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${BuildLogGroup}:log-stream:*"
+              - Effect: Allow
+                Action:
+                  - ecr:CompleteLayerUpload
+                  - ecr:GetAuthorizationToken
+                  - ecr:UploadLayerPart
+                  - ecr:InitiateLayerUpload
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:PutImage
+                  - ecs:RegisterTaskDefinition
+                  - ecs:UpdateService
+                  - ecs:DescribeServices
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: '*'
+
+  BuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "${StackFamily}-queue-worker-build"
+      Artifacts:
+        Type: CODEPIPELINE
+      ServiceRole: !Ref BuildRole
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: aws/code-build/queue-worker/buildspec.yml
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:4.0
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Sub ${AWS::AccountId}
+            Type: PLAINTEXT
+          - Name: PROJECT_NAMESPACE
+            Value: !Ref StackFamily
+            Type: PLAINTEXT
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref BuildLogGroup
+          Status: ENABLED
+
+  PipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "codepipeline.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        -
+          PolicyName: CodePipeline
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:BatchGetBuilds
+                  - codebuild:StartBuild
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:List*
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+                Resource:
+                  - !Join ['', ['arn:aws:s3:::', !Ref PilelineArtifactStore]]
+                  - !Join ['', ['arn:aws:s3:::', !Ref PilelineArtifactStore, '/*']]
+              - Effect: Allow
+                Action:
+                  - ecs:*
+                  - iam:PassRole
+                Resource: "*"
+
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      Name: !Sub "${StackFamily}-queue-worker-pipeline"
+      RoleArn: !GetAtt PipelineRole.Arn
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: Source
+              ActionTypeId:
+                Category: Source
+                Owner: ThirdParty
+                Provider: GitHub
+                Version: 1
+              Configuration:
+                Owner: !Ref GitHubOwner
+                Repo: !Ref GitHubRepository
+                PollForSourceChanges: false
+                Branch: !Ref GitHubBranch
+                OAuthToken: !Sub "{{resolve:secretsmanager:${StackFamily}-secrets-github:SecretString:access-token}}"
+              OutputArtifacts:
+                - Name: SourceArtifact
+        - Name: Build_And_Deploy
+          Actions:
+            - Name: Build_and_Deploy
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: 1
+              Configuration:
+                ProjectName: !Ref BuildProject
+              InputArtifacts:
+                - Name: SourceArtifact
+              Region: ap-northeast-1
+      ArtifactStore:
+        Type: S3
+        Location: !Ref PilelineArtifactStore
+
+  PipelineWebhook:
+    Type: AWS::CodePipeline::Webhook
+    Properties:
+      Authentication: GITHUB_HMAC
+      AuthenticationConfiguration:
+        SecretToken: !Sub "{{resolve:secretsmanager:${StackFamily}-secrets-github:SecretString:access-token}}"
+      Filters:
+        - JsonPath: $.ref
+          MatchEquals: refs/heads/{Branch}
+      TargetAction: Source
+      TargetPipeline: !Ref Pipeline
+      TargetPipelineVersion: !GetAtt Pipeline.Version
+      RegisterWithThirdParty: true

--- a/aws/cloud-formation/queue-worker/ecs-ecr.yml
+++ b/aws/cloud-formation/queue-worker/ecs-ecr.yml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  StackFamily:
+    Type: String
+    Default: ecs-blue-green-demo
+
+Resources:
+  EcrTaskScheduler:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Sub "${StackFamily}/queue-worker"
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Delete more than 20 images",
+                "selection": {
+                  "tagStatus": "any",
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 20
+                },
+                "action": {
+                  "type": "expire"
+                }
+              }
+            ]
+          }
+
+Outputs:
+  EcrNginx:
+    Value: !Ref EcrTaskScheduler
+    Export:
+      Name: !Sub "${StackFamily}-ecr-queue-worker"

--- a/aws/cloud-formation/queue-worker/ecs-service.yml
+++ b/aws/cloud-formation/queue-worker/ecs-service.yml
@@ -1,0 +1,73 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  StackFamily:
+    Type: String
+    Default: ecs-blue-green-demo
+  EcsDesiredCount:
+    Type: Number
+    Default: 1
+  EcsCpu:
+    Type: Number
+    Default: 512
+  TaskMemory:
+    Type: Number
+    Default: 1024
+  QueueWorkerMemory:
+    Type: Number
+    Default: 1024
+
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "${StackFamily}-queue-worker"
+      RetentionInDays: 14
+
+  ECSTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "${StackFamily}-queue-worker"
+      Memory: !Ref TaskMemory
+      ExecutionRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${StackFamily}-ecs-execution"
+      TaskRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${StackFamily}-ecs-task"
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: !Ref EcsCpu
+      ContainerDefinitions:
+        - Name: queue-worker
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${StackFamily}/queue-worker:latest"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+          Ulimits:
+            - Name: nofile
+              SoftLimit: 65536
+              HardLimit: 65536
+          Memory: !Ref QueueWorkerMemory
+
+  ECSService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster:
+        Fn::ImportValue:
+          !Sub "${StackFamily}-ecs-cluster"
+      LaunchType: FARGATE
+      TaskDefinition: !Ref ECSTaskDefinition
+      DesiredCount: !Ref EcsDesiredCount
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - Fn::ImportValue:
+                !Sub "${StackFamily}-private-subnet-1a"
+            - Fn::ImportValue:
+                !Sub "${StackFamily}-private-subnet-1d"
+          SecurityGroups:
+            - Fn::ImportValue:
+                !Sub "${StackFamily}-app-sg"
+      ServiceName: !Sub "${StackFamily}-queue-worker"

--- a/aws/code-build/queue-worker/buildspec.yml
+++ b/aws/code-build/queue-worker/buildspec.yml
@@ -1,0 +1,36 @@
+version: 0.2
+
+env:
+  secrets-manager:
+    DOCKER_USERNAME: "ecs-blue-green-demo-secrets-docker:username"
+    DOCKER_PASSWORD: "ecs-blue-green-demo-secrets-docker:access-token"
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws --version
+      - aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+      - echo Logging in to Docker Hub...
+      - echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+      - IMAGE_NAME_QUEUE_WORKER=queue-worker
+      - REPOSITORY_URI_QUEUE_WORKER=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAMESPACE}/${IMAGE_NAME_QUEUE_WORKER}
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo composer install
+      - cp $PWD/app/.env.example $PWD/app/.env
+      - docker run --rm --volume $PWD/app:/app composer:1.10.16 install --no-dev
+      - echo Building the Docker image...
+      - docker build -t ${REPOSITORY_URI_QUEUE_WORKER}:latest -f aws/ecs/queue-worker/Dockerfile .
+      - docker tag ${REPOSITORY_URI_QUEUE_WORKER}:latest ${REPOSITORY_URI_QUEUE_WORKER}:$IMAGE_TAG
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push ${REPOSITORY_URI_QUEUE_WORKER}:latest
+      - docker push ${REPOSITORY_URI_QUEUE_WORKER}:$IMAGE_TAG
+      - cat aws/ecs/queue-worker/taskdef.json | sed -e "s/<PROJECT_NAMESPACE>/${PROJECT_NAMESPACE}/g" -e "s/<AWS_ACCOUNT_ID>/${AWS_ACCOUNT_ID}/g" -e "s/<AWS_REGION>/${AWS_DEFAULT_REGION}/g" -e "s/<IMAGE_TAG>/${IMAGE_TAG}/g" > taskdef.json
+      - aws ecs register-task-definition --cli-input-json file://taskdef.json

--- a/aws/ecs/queue-worker/Dockerfile
+++ b/aws/ecs/queue-worker/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:7.4-cli-alpine
+
+RUN set -ex \
+  && apk --no-cache add \
+    autoconf gcc g++ make libzip-dev git
+
+RUN docker-php-ext-install zip pdo pdo_mysql opcache
+
+WORKDIR /app
+
+ADD ./app /app
+
+RUN chmod -R a+w storage/ bootstrap/cache
+
+CMD ["php", "artisan", "queue:listen"]

--- a/aws/ecs/queue-worker/taskdef.json
+++ b/aws/ecs/queue-worker/taskdef.json
@@ -1,0 +1,38 @@
+{
+  "family": "<PROJECT_NAMESPACE>-queue-worker",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024",
+  "networkMode": "awsvpc",
+  "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/<PROJECT_NAMESPACE>-ecs-execution",
+  "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/<PROJECT_NAMESPACE>-ecs-task",
+  "containerDefinitions": [
+    {
+      "name": "queue-worker",
+      "image": "<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/<PROJECT_NAMESPACE>/queue-worker:<IMAGE_TAG>",
+      "essential": true,
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 65536,
+          "hardLimit": 65536
+        }
+      ],
+      "memory": 1024,
+      "environment": [
+      ],
+      "secrets": [
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "<PROJECT_NAMESPACE>-queue-worker",
+          "awslogs-region": "<AWS_REGION>",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,5 +30,13 @@ services:
       - ./app:/app:cached
     working_dir: /app
 
+  queue-worker:
+    build:
+      context: .
+      dockerfile: ./local/docker/queue-worker/Dockerfile
+    volumes:
+      - ./app:/app:cached
+    working_dir: /app
+
 volumes:
   uds:

--- a/local/docker/queue-worker/Dockerfile
+++ b/local/docker/queue-worker/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:7.4-cli-alpine
+
+RUN set -ex \
+  && apk --no-cache add \
+    autoconf gcc g++ make libzip-dev git
+
+RUN docker-php-ext-install zip pdo pdo_mysql opcache
+
+CMD ["php", "artisan", "queue:listen"]


### PR DESCRIPTION
## やること
### キューを実装
- https://github.com/yields-llc/ecs-blue-green-demo/pull/2/commits/39161534f64bef668fe032deda8488cb54a356a1
- `$ docker-compose up -d`し、`http://localhost:8000/queues`にアクセスし、ログが出ていれば完了

### キューワーカーサービスを構築
- https://github.com/yields-llc/ecs-blue-green-demo/pull/2/commits/1c736fc4596e3c81d94260c5b8f49d24310b0c97
- 追加でこちらも
  - https://github.com/yields-llc/ecs-blue-green-demo/compare/1c736fc...fbfaaf943c
  - `aws/code-build/queue-worker/buildspec.yml` に1行追記お願いします
- `$ make deploy-queue-worker-ecs-ecr profile=$(profile)`
- `$ make push-queue-worker-docker-images profile=$(profile)` 
- `$ make deploy-queue-worker-ecs-service profile=$(profile)` 
- `$ make deploy-queue-worker-code-pipeline profile=$(profile)`
  - `CodePipeline`はエラーになるので、`git add / commit / push`する
- `http://ecs-blue-green-demo-app-XXXXXXXXX.ap-northeast-1.elb.amazonaws.com/queues` ページにアクセスし、`CloudWatch Logs`にログが出ていれば完了

### キュードライバーをSQSに変更
- https://github.com/yields-llc/ecs-blue-green-demo/compare/1c736fc...fbfaaf943c
  - `composer.json / composer.lock` 後で `composer require` するので編集不要です
  - `.env.example`の`SQS_PREFIX=https://sqs.ap-northeast-1.amazonaws.com/${AWS_ACOUNT_ID}`は環境ごとに違うので書き換える
- `$ make deploy-queue-worker-sqs profile=$(profile)`
- `docker-compose run --rm php-fpm composer require aws/aws-sdk-php-laravel`
- SQSの操作権限がないので、`$ make deploy-ecs-service profile=$(profile)` を実行する
  - が、`Failed to create the changeset: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Transform AWS::CodeDeployBlueGreen failed with: Failed to transform template. The provided template did not include an expected Hook of type "AWS::CodeDeploy::BlueGreen".
`というエラーになるので、
  -  `CloudFormation`のページから`ecs-blue-green-demo-ecs-service`スタックをいったん削除して再実行
- `git add / commit / push`
